### PR TITLE
fixed Sidebar links not working

### DIFF
--- a/packages/lib/src/sidenav.ts
+++ b/packages/lib/src/sidenav.ts
@@ -405,8 +405,8 @@ export const SidenavItem: FactoryComponent<SidenavItemAttrs> = () => {
         .join(' ') || undefined;
 
       const handleMainClick = (e: Event) => {
-        e.preventDefault();
         if (hasSubmenu) {
+          e.preventDefault();
           isSubmenuOpen = active ? !isSubmenuOpen : true;
         }
         if (onclick && !disabled) {


### PR DESCRIPTION
Fixes #24 . Sidebar links had their default behavior canceled, even when they were links and not submenus. Now, sidebar items that are links with an href will change the route. Sidebar items that have submenus will continue to work as well.

## Summary by Sourcery

Bug Fixes:
- Do not prevent default click behavior for sidebar items without submenus to restore link navigation