### PR TITLE
ci: upgrade to skill-review-and-optimize + add /apply-optimize workflow

### DIFF
--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -1,0 +1,24 @@
+# Apply optimized SKILL.md content from review comment when someone comments /apply-optimize.
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Apply skill optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: tesslio/skill-review-and-optimize@main
+        with:
+          mode: apply

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,15 +1,12 @@
-# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
-# Docs: https://github.com/tesslio/skill-review
-name: Tessl Skill Review
+# Tessl Skill Review & Optimize — review on PRs that touch SKILL.md (no secrets required).
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Skill review and optimize
 
 on:
   pull_request:
     branches: [master]
     paths:
       - "**/SKILL.md"
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   review:
@@ -18,8 +15,12 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: tesslio/skill-review@main
-      # Optional quality gate (off by default — do not enable unless user asked):
-      # with:
-      #   fail-threshold: 70
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@main
+        # Review-only by default — works without TESSL_API_TOKEN.
+        # Optional: enable optimize after adding repo secret TESSL_API_TOKEN:
+        # with:
+        #   optimize: true
+        #   tessl-token: ${{ secrets.TESSL_API_TOKEN }}
+        # Optional quality gate:
+        #   fail-threshold: 70


### PR DESCRIPTION
Hey @erikvullings 👋

Following up on [the skill optimization PR that was merged](https://github.com/erikvullings/mithril-materialized/pull/41) — this upgrades the existing Tessl review workflow to **[tesslio/skill-review-and-optimize](https://github.com/tesslio/skill-review-and-optimize)** and adds a second workflow for `/apply-optimize`, so future PRs that touch `SKILL.md` can get AI-suggested improvements applied in one comment.

## What this changes

**`.github/workflows/skill-review.yml`** — upgraded from `tesslio/skill-review` to `tesslio/skill-review-and-optimize`:
- Review mode works with **zero secrets** — same scores + feedback as before, out of the box
- Maintainers can now unlock **AI optimization suggestions** by adding `TESSL_API_TOKEN` and setting `optimize: true`
- Still posts/updates a **single PR comment** — no comment spam

**`.github/workflows/skill-optimize-apply.yml`** — new workflow triggered by `/apply-optimize` comment on a PR:
- Commits the AI-suggested improved `SKILL.md` content directly to the PR branch — no copy-paste needed
- Only fires when a PR comment contains `/apply-optimize`

## How to enable optimize mode (optional)

1. Add a `TESSL_API_TOKEN` secret: **Settings → Secrets and variables → Actions → New repository secret**
   Get a free token at https://tessl.io/account/api-keys
2. Uncomment the `with:` block in `skill-review.yml`:
   ```yaml
   with:
     optimize: true
     tessl-token: ${{ secrets.TESSL_API_TOKEN }}
   ```
3. On any PR touching `SKILL.md`, the review comment will now include AI-suggested improved content — and contributors can comment `/apply-optimize` to auto-commit it.

> Without the token, the workflow still posts review scores and feedback — just without the AI optimization suggestions.

## What stays the same

- **Non-blocking by default** — no red CI unless you add `fail-threshold`
- **Only fires on `**/SKILL.md` PRs** — no noise on other changes
- **Contributors need no Tessl account** — only the repo owner needs the API token for optimization

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏

## Summary by Sourcery

Upgrade the Tessl skill review GitHub Actions workflow and add a companion workflow to apply AI-optimized SKILL.md content from PR comments.

CI:
- Switch the SKILL review workflow to use tesslio/skill-review-and-optimize with optional optimization and quality gate settings, and update the action checkout version.
- Introduce a new issue_comment-triggered workflow that applies optimized SKILL.md changes to PR branches when a /apply-optimize comment is posted.